### PR TITLE
Get version from release branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Finally, you can reliably get the pushed version on every platform.
 
 ### `version`
 
-The pushed version. If `github.ref` was `/refs/tags/v1.2.7` then the value of this output will be `v1.2.7`.
+The pushed version. If `github.ref` was `refs/tags/v1.2.7` or `refs/heads/release/v1.2.7` then the value of this output will be `v1.2.7`.
 
 ### `version-without-v`
 

--- a/action.yml
+++ b/action.yml
@@ -2,9 +2,9 @@ name: 'Get Version'
 description: 'Extracts the version from github.ref.'
 outputs:
   version:
-    description: 'The pushed tag version, for example "v1.2.7"'
+    description: 'The pushed version, for example "v1.2.7"'
   version-without-v:
-    description: 'The pushed tag version, without the v prefix, for example "1.2.7"'
+    description: 'The pushed version, without the v prefix, for example "1.2.7"'
 runs:
   using: 'node12'
   main: 'index.js'

--- a/index.js
+++ b/index.js
@@ -2,7 +2,8 @@ const core = require('@actions/core')
 const github = require('@actions/github')
 
 try {
-  const version = github.context.ref.replace('refs/tags/', '')
+  const pattern = /refs\/tags\/|refs\/heads\/release\//;
+  const version = github.context.ref.replace(pattern, '')
 
   let versionWithoutV = version
   if (version.startsWith('v')) {


### PR DESCRIPTION
Hi, 

I use [gitflow](https://www.atlassian.com/git/tutorials/comparing-workflows/gitflow-workflow) in my development process and I would like to get version number from release branch, `release/v1.2.7`, instead of tag

Best regards